### PR TITLE
Bugfix for when maxLoad > tasks.length

### DIFF
--- a/lib/Scheduler.js
+++ b/lib/Scheduler.js
@@ -19,6 +19,7 @@ Scheduler.prototype._execute = function(res,rej){
 
     for(var i=0;
         i<this.maxLoad &&
+	this.tasks.length > 0 &&
         this.maxLoad>this.runningTasks;
         i++){
         var task = this.tasks.shift();


### PR DESCRIPTION
Say if we have only 5 tasks but our maxLoad is set to 15, the current code would keep trying to `shift` new tasks to run until we reach the limit. 

This fix makes sure that there are tasks left to be dequeued. 